### PR TITLE
Fix URL to web-push GitHub repo

### DIFF
--- a/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
+++ b/app/content/pages/articles/web-push-notifications-from-rails.html.mdrb
@@ -120,7 +120,7 @@ Breaking it down:
    to be sent.
 
 1. To send a push notification, we’ll use the
-   [`web-push`](https://github.com/push-pad/web-push) Ruby gem triggered from our
+   [`web-push`](https://github.com/pushpad/web-push) Ruby gem triggered from our
    Rails app. `web-push` is responsible for [encrypting of the message
    payload](https://developers.google.com/web/updates/2016/03/web-push-encryption?hl=en)
    and sending the request to "push" the notification for the given subscription


### PR DESCRIPTION
Hey @rossta, I just found a tiny typo in the web-push gem link in the ["Sending Web Push Notifications from Rails"](https://joyofrails.com/articles/web-push-notifications-from-rails) article. 

This PR removes the additional dash in the web-push maintainer’s GitHub username (should be `pushpad` instead of `push-pad`).

Also, thanks for the great article – it saved me a lot of time! :pray:
